### PR TITLE
1000 uuids stats chunk

### DIFF
--- a/collectors/ClusterPropertiesCollector.py
+++ b/collectors/ClusterPropertiesCollector.py
@@ -2,7 +2,7 @@ from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.core import InfoMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
 
@@ -10,7 +10,7 @@ import os
 class ClusterPropertiesCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.property_yaml = YamlRead('collectors/property.yaml').run()
+        self.property_yaml = yaml_read('collectors/property.yaml')
         self.name = self.__class__.__name__
         # self.post_registered_collector(self.name, self.g.name, self.i.name + '_info')
 

--- a/collectors/ClusterStatsCollector.py
+++ b/collectors/ClusterStatsCollector.py
@@ -1,7 +1,7 @@
 from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
 
@@ -9,7 +9,7 @@ import os
 class ClusterStatsCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.statkey_yaml = YamlRead('collectors/statkey.yaml').run()
+        self.statkey_yaml = yaml_read('collectors/statkey.yaml')
         self.name = self.__class__.__name__
         # self.post_registered_collector(self.name, g.name)
 

--- a/collectors/DatastoreStatsCollector.py
+++ b/collectors/DatastoreStatsCollector.py
@@ -1,7 +1,7 @@
 from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
 
@@ -9,7 +9,7 @@ import os
 class DatastoreStatsCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.statkey_yaml = YamlRead('collectors/statkey.yaml').run()
+        self.statkey_yaml = yaml_read('collectors/statkey.yaml')
         # self.post_registered_collector(self.__class__.__name__, self.g.name)
 
     def describe(self):

--- a/collectors/HostSystemPropertiesCollector.py
+++ b/collectors/HostSystemPropertiesCollector.py
@@ -2,7 +2,7 @@ from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.core import InfoMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
 
@@ -10,7 +10,7 @@ import os
 class HostSystemPropertiesCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.property_yaml = YamlRead('collectors/property.yaml').run()
+        self.property_yaml = yaml_read('collectors/property.yaml')
         self.name = self.__class__.__name__
         # self.post_registered_collector(self.name, self.g.name, self.i.name + '_info')
 

--- a/collectors/HostSystemStatsCollector.py
+++ b/collectors/HostSystemStatsCollector.py
@@ -1,7 +1,7 @@
 from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
 
@@ -9,7 +9,7 @@ import os
 class HostSystemStatsCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.statkey_yaml = YamlRead('collectors/statkey.yaml').run()
+        self.statkey_yaml = yaml_read('collectors/statkey.yaml')
         # self.post_registered_collector(self.__class__.__name__, self.g.name)
 
     def describe(self):

--- a/collectors/VMPropertiesCollector.py
+++ b/collectors/VMPropertiesCollector.py
@@ -2,7 +2,7 @@ from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.core import InfoMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
 
@@ -10,7 +10,7 @@ import os
 class VMPropertiesCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.property_yaml = YamlRead('collectors/property.yaml').run()
+        self.property_yaml = yaml_read('collectors/property.yaml')
         self.name = self.__class__.__name__
         # self.post_registered_collector(self.name, g.name, i.name + '_info')
 

--- a/collectors/VMStatsCollector.py
+++ b/collectors/VMStatsCollector.py
@@ -1,15 +1,16 @@
 from BaseCollector import BaseCollector
 from prometheus_client.core import GaugeMetricFamily
 from tools.Resources import Resources
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from threading import Thread
 import os
+import json
 
 
 class VMStatsCollector(BaseCollector):
     def __init__(self):
         self.wait_for_inventory_data()
-        self.statkey_yaml = YamlRead('collectors/statkey.yaml').run()
+        self.statkey_yaml = yaml_read('collectors/statkey.yaml')
         # self.post_registered_collector(self.__class__.__name__, g.name)
 
     def describe(self):
@@ -38,10 +39,17 @@ class VMStatsCollector(BaseCollector):
             print("skipping " + target + " in VMStatsCollector, no token")
 
         uuids = self.target_vms[target]
+        print(target)
+        print("amount uuids",str(len(uuids)))
+        with open('uuids','w') as f:
+            json.dump(uuids,f)
         for statkey_pair in self.statkey_yaml["VMStatsCollector"]:
             statkey_label = statkey_pair['label']
             statkey = statkey_pair['statkey']
             values = Resources.get_latest_stat_multiple(target, token, uuids, statkey)
+            print("fetched     ", str(len(values)))
+            # with open('values_4vms','w') as f:
+                # json.dump(values,f)
             if not values:
                 print("skipping statkey " + str(statkey) + " in VMStatsCollector, no return")
                 continue

--- a/tests/TestCollectors.py
+++ b/tests/TestCollectors.py
@@ -3,7 +3,7 @@ sys.path.append('.')
 from unittest.mock import MagicMock
 from threading import Thread
 from exporter import run_prometheus_server
-from tools.YamlRead import YamlRead
+from tools.helper import yaml_read
 from tools.Resources import Resources
 from InventoryBuilder import InventoryBuilder
 from collectors.HostSystemStatsCollector import HostSystemStatsCollector
@@ -27,7 +27,7 @@ class TestCollectors(unittest.TestCase):
         self.assertTrue(os.getenv('PASSWORD'), 'no dummy PASSWORD set')
 
     def test_collector_metrics(self):
-        metrics_yaml = YamlRead('tests/metrics.yaml').run()
+        metrics_yaml = yaml_read('tests/metrics.yaml')
 
         # every collector got to be tested in here
         random_prometheus_port = random.randrange(9000, 9700, 1)
@@ -39,20 +39,20 @@ class TestCollectors(unittest.TestCase):
 
         Resources.get_datacenter = MagicMock(
             return_value=[{'name': 'datacenter1', 'uuid': '5628-9ba1-55e847050814'},
-                          {'name': 'datacenter2', 'uuid': '5628-9ba1-55e847050814'}])
+                          {'name': 'datacenter2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_cluster = MagicMock(return_value=[{'name': 'cluster1', 'uuid': '3628-93a1-56e84634050814'},
-                                                        {'name': 'cluster2', 'uuid': '5628-9ba1-55e847050814'}])
+                                                        {'name': 'cluster2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_hosts = MagicMock(return_value=[{'name': 'hostsystem1', 'uuid': '3628-93a1-56e84634050814'},
-                                                      {'name': 'hostsystem2', 'uuid': '5628-9ba1-55e847050814'}])
+                                                      {'name': 'hostsystem2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_vmfolders = MagicMock(return_value=[{'name': 'vmfolder1', 'uuid': '3628-93a1-56e84634050814'},
-                                                          {'name': 'vmfolder2', 'uuid': '5628-9ba1-55e847050814'}])
+                                                          {'name': 'vmfolder2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_virtualmachines = MagicMock(return_value=[{'name': 'vm1', 'uuid': '3628-93a1-56e84634050814'},
-                                                                {'name': 'vm2', 'uuid': '5628-9ba1-55e847050814'}])
+                                                                {'name': 'vm2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_datastores = MagicMock(
             return_value=[{'name': 'datastore1', 'uuid': '3628-93a1-56e84634050814'},
-                          {'name': 'datastore2', 'uuid': '5628-9ba1-55e847050814'}])
+                          {'name': 'datastore2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_resources = MagicMock(return_value=[{'name': 'resource1', 'uuid': '5628-9ba1-55e847050814'},
-                                                          {'name': 'resource2', 'uuid': '5628-9ba1-55e847050814'}])
+                                                          {'name': 'resource2', 'uuid': '5628-9ba1-55e847050815'}])
         Resources.get_latest_stat = MagicMock(return_value=1)
         Resources.get_property = MagicMock(return_value="test_property")
         thread = Thread(target=InventoryBuilder, args=('./tests/test.json', 8000,))
@@ -64,17 +64,17 @@ class TestCollectors(unittest.TestCase):
 
             if 'Stats' in collector:
                 # mocking all values from yaml
-                statkey_yaml = YamlRead('collectors/statkey.yaml').run()
+                statkey_yaml = yaml_read('collectors/statkey.yaml')
                 multiple_metrics_generated = list()
                 for statkey_pair in statkey_yaml[collector]:
                     multiple_metrics_generated.append({"resourceId": "3628-93a1-56e84634050814", "stat-list": {"stat": [
                         {"timestamps": [1582797716394], "statKey": {"key": statkey_pair['statkey']}, "data": [88.0]}]}})
-                    multiple_metrics_generated.append({"resourceId": "5628-9ba1-55e847050814", "stat-list": {"stat": [
+                    multiple_metrics_generated.append({"resourceId": "5628-9ba1-55e847050815", "stat-list": {"stat": [
                         {"timestamps": [1582797716394], "statKey": {"key": statkey_pair['statkey']}, "data": [44.0]}]}})
                 Resources.get_latest_stat_multiple = MagicMock(return_value=multiple_metrics_generated)
 
             if "Properties" in collector:
-                propkey_yaml = YamlRead('collectors/property.yaml').run()
+                propkey_yaml = yaml_read('collectors/property.yaml')
                 multiple_enum_properties_generated = list()
                 if 'enum_metrics' in propkey_yaml[collector]:
                     for propkey_pair in propkey_yaml[collector]['enum_metrics']:
@@ -82,7 +82,7 @@ class TestCollectors(unittest.TestCase):
                                                                    'propkey': propkey_pair['property'],
                                                                    'data': 0,
                                                                    'latest_state': 'test_enum_property'})
-                        multiple_enum_properties_generated.append({'resourceId': "5628-9ba1-55e847050814",
+                        multiple_enum_properties_generated.append({'resourceId': "5628-9ba1-55e847050815",
                                                                    'propkey': propkey_pair['property'],
                                                                    'data': 0,
                                                                    'latest_state': 'test_enum_property'})
@@ -95,7 +95,7 @@ class TestCollectors(unittest.TestCase):
                         multiple_number_properties_generated.append({'resourceId': '3628-93a1-56e84634050814',
                                                                      'propkey': propkey_pair['property'],
                                                                      'data': 19.54})
-                        multiple_number_properties_generated.append({'resourceId': "5628-9ba1-55e847050814",
+                        multiple_number_properties_generated.append({'resourceId': "5628-9ba1-55e847050815",
                                                                      'propkey': propkey_pair['property'],
                                                                      'data': '6.5'})
                 Resources.get_latest_number_properties_multiple = MagicMock(
@@ -107,7 +107,7 @@ class TestCollectors(unittest.TestCase):
                         multiple_info_properties_generated.append({'resourceId': '3628-93a1-56e84634050814',
                                                                    'propkey': propkey_pair['property'],
                                                                    'data': 'test_info_property'})
-                        multiple_info_properties_generated.append({'resourceId': "5628-9ba1-55e847050814",
+                        multiple_info_properties_generated.append({'resourceId': "5628-9ba1-55e847050815",
                                                                    'propkey': propkey_pair['property'],
                                                                    'data': 'test_info_property'})
                 Resources.get_latest_info_properties_multiple = MagicMock(

--- a/tools/Resources.py
+++ b/tools/Resources.py
@@ -381,7 +381,7 @@ class Resources:
             'Authorization': "vRealizeOpsToken " + token
         }
 
-        m = MultipleThread0r()
+        m = ChunkFechter()
         thread_list = list()
         for uuid_list in uuids_chunked:
             t = Thread(target=m.get_chunk, args=(uuid_list, url, headers, key, target))
@@ -392,7 +392,7 @@ class Resources:
         return m.return_list
 
 # helper class to allow to thread
-class MultipleThread0r:
+class ChunkFetcher:
     def __init__(self):
         self.return_list = list()
         self.chunk_iteration = 0

--- a/tools/Resources.py
+++ b/tools/Resources.py
@@ -381,7 +381,7 @@ class Resources:
             'Authorization': "vRealizeOpsToken " + token
         }
 
-        m = ChunkFechter()
+        m = ChunkFetcher()
         thread_list = list()
         for uuid_list in uuids_chunked:
             t = Thread(target=m.get_chunk, args=(uuid_list, url, headers, key, target))

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -1,0 +1,3 @@
+def chunk_list(lst, n):
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -1,3 +1,13 @@
 def chunk_list(lst, n):
     for i in range(0, len(lst), n):
         yield lst[i:i + n]
+
+def yaml_read(path):
+    import yaml
+    yml = dict()
+    with open(path, 'r') as stream:
+        try:
+            yml = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+    return yml


### PR DESCRIPTION
if more than 1000uuids are queried at the same time, all but first 1000 are dropped. This is mitigating it and introducing threading for fetching stats, otherwise this will increase runtime significantly