### PR TITLE
VMs should not be included by default

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -20,8 +20,8 @@ def default_collectors():
         'DatastoreStatsCollector',
         'VMStatsCollector',
         'VMPropertiesCollector',
-        'VCenterStatsCollector',
-        'VCenterPropertiesCollector'
+        # 'VCenterStatsCollector',
+        # 'VCenterPropertiesCollector'
     ]
 
 


### PR DESCRIPTION
since the new uuid mechanism the scrapes are getting to long again. separating VM tasks here should achieve two things:
* consistent metrics, if VMs are taking too long
* federateable metrics for VMs too