### PR TITLE
VMs disabled by default #2

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -18,8 +18,8 @@ def default_collectors():
         'HostSystemStatsCollector',
         'HostSystemPropertiesCollector',
         'DatastoreStatsCollector',
-        'VMStatsCollector',
-        'VMPropertiesCollector',
+        # 'VMStatsCollector',
+        # 'VMPropertiesCollector',
         'VCenterStatsCollector',
         'VCenterPropertiesCollector'
     ]


### PR DESCRIPTION
since the new uuid mechanism the scrapes are getting to long again. separating VM tasks here should achieve two things:

- consistent metrics, if VMs are taking too long
- federateable metrics for VMs too