### PR TITLE
as long as the target is not in inventory

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -11,10 +11,10 @@ class BaseCollector(ABC):
 
     def __init__(self):
         self.vrops_entity_name = 'base'
-        if os.environ['TARGET'] in self.get_target_tokens():
-            self.target = os.environ['TARGET']
-        else:
+        while os.environ['TARGET'] not in self.get_target_tokens():
             print(os.environ['TARGET'], "has no resources in inventory")
+            time.sleep(1800)
+        self.target = os.environ['TARGET']
 
     @abstractmethod
     def collect(self):


### PR DESCRIPTION

Example error from `vrops-exporter-vrops-vc-b-0-host`

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/usr/lib/python3.8/site-packages/prometheus_client/exposition.py", line 52, in prometheus_app
    status, header, output = _bake_output(registry, accept_header, params)
  File "/usr/lib/python3.8/site-packages/prometheus_client/exposition.py", line 40, in _bake_output
    output = encoder(registry)
  File "/usr/lib/python3.8/site-packages/prometheus_client/openmetrics/exposition.py", line 14, in generate_latest
    for metric in registry.collect():
  File "/usr/lib/python3.8/site-packages/prometheus_client/registry.py", line 82, in collect
    for metric in collector.collect():
  File "/vrops-exporter/collectors/HostSystemStatsCollector.py", line 24, in collect
    token = token[self.target]
AttributeError: 'HostSystemStatsCollector' object has no attribute 'target'
```