### PR TITLE
added api response metric

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -132,10 +132,14 @@ class BaseCollector(ABC):
         return
 
     def create_http_response_metric(self, target, token, collector):
-        http_response_code = Vrops.get_http_response_code(target, token)
-        http_gauge = GaugeMetricFamily('vrops_http_response_code', 'vrops-exporter', labels=['target', 'class'])
-        http_gauge.add_metric(labels=[self.target, collector.lower()], value=http_response_code)
-        return http_response_code, http_gauge
+        api_responding = Vrops.get_http_response_code(target, token)
+        gauge = GaugeMetricFamily('vrops_api_response', 'vrops-exporter', labels=['target', 'class'])
+        gauge.add_metric(labels=[self.target, collector.lower()], value=api_responding)
+
+        if api_responding > 200:
+            logger.critical(f'API response {api_responding} [{collector}, {self.target}], no return')
+            return False, gauge
+        return True, gauge
 
     def generate_gauges(self, metric_type, calling_class, vrops_entity_name, labelnames, rubric=None):
         if not isinstance(labelnames, list):

--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -131,6 +131,12 @@ class BaseCollector(ABC):
         logger.info(f'-----Initial query done------: {self.collector}')
         return
 
+    def create_http_response_metric(self, target, token, collector):
+        http_response_code = Vrops.get_http_response_code(target, token)
+        http_gauge = GaugeMetricFamily('vrops_http_response_code', 'vrops-exporter', labels=['target', 'class'])
+        http_gauge.add_metric(labels=[self.target, collector.lower()], value=http_response_code)
+        return http_response_code, http_gauge
+
     def generate_gauges(self, metric_type, calling_class, vrops_entity_name, labelnames, rubric=None):
         if not isinstance(labelnames, list):
             logger.error(f'Cannot generate Gauges without label list, called from {calling_class}')

--- a/collectors/ClusterPropertiesCollector.py
+++ b/collectors/ClusterPropertiesCollector.py
@@ -23,6 +23,14 @@ class ClusterPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,
                                       ['vcenter', 'vccluster', 'datacenter'])
         infos = self.generate_infos(self.name, self.vrops_entity_name,

--- a/collectors/ClusterPropertiesCollector.py
+++ b/collectors/ClusterPropertiesCollector.py
@@ -23,12 +23,10 @@ class ClusterPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,

--- a/collectors/ClusterStatsCollector.py
+++ b/collectors/ClusterStatsCollector.py
@@ -23,15 +23,14 @@ class ClusterStatsCollector(BaseCollector):
             logger.warning(f'skipping { self.target } in { self.name }, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
+
+        if not api_responding:
+            return
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       ['vcenter', 'vccluster', 'datacenter'])
-        if not gauges and http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
-            return
 
         uuids = self.get_clusters_by_target()
         for metric_suffix in gauges:

--- a/collectors/ClusterStatsCollector.py
+++ b/collectors/ClusterStatsCollector.py
@@ -23,9 +23,14 @@ class ClusterStatsCollector(BaseCollector):
             logger.warning(f'skipping { self.target } in { self.name }, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       ['vcenter', 'vccluster', 'datacenter'])
-        if not gauges:
+        if not gauges and http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
             return
 
         uuids = self.get_clusters_by_target()

--- a/collectors/ClusterStatsCollector.py
+++ b/collectors/ClusterStatsCollector.py
@@ -31,6 +31,8 @@ class ClusterStatsCollector(BaseCollector):
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       ['vcenter', 'vccluster', 'datacenter'])
+        if not gauges:
+            return
 
         uuids = self.get_clusters_by_target()
         for metric_suffix in gauges:

--- a/collectors/DatastorePropertiesCollector.py
+++ b/collectors/DatastorePropertiesCollector.py
@@ -23,12 +23,10 @@ class DatastorePropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,

--- a/collectors/DatastorePropertiesCollector.py
+++ b/collectors/DatastorePropertiesCollector.py
@@ -23,6 +23,14 @@ class DatastorePropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'type', 'vcenter', 'datacenter', 'vccluster',
                                        'hostsystem'])

--- a/collectors/DatastoreStatsCollector.py
+++ b/collectors/DatastoreStatsCollector.py
@@ -23,12 +23,10 @@ class DatastoreStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,

--- a/collectors/DatastoreStatsCollector.py
+++ b/collectors/DatastoreStatsCollector.py
@@ -23,6 +23,14 @@ class DatastoreStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'type', 'vcenter', 'datacenter', 'vccluster',
                                        'hostsystem'])

--- a/collectors/DatastoreStatsCollector.py
+++ b/collectors/DatastoreStatsCollector.py
@@ -32,6 +32,8 @@ class DatastoreStatsCollector(BaseCollector):
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'type', 'vcenter', 'datacenter', 'vccluster',
                                        'hostsystem'])
+        if not gauges:
+            return
 
         uuids = self.get_datastores_by_target()
         for metric_suffix in gauges:

--- a/collectors/HostSystemPropertiesCollector.py
+++ b/collectors/HostSystemPropertiesCollector.py
@@ -23,12 +23,10 @@ class HostSystemPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,

--- a/collectors/HostSystemPropertiesCollector.py
+++ b/collectors/HostSystemPropertiesCollector.py
@@ -23,6 +23,14 @@ class HostSystemPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'vcenter', 'datacenter', 'vccluster'])
         infos = self.generate_infos(self.name, self.vrops_entity_name,

--- a/collectors/HostSystemStatsCollector.py
+++ b/collectors/HostSystemStatsCollector.py
@@ -31,6 +31,8 @@ class HostSystemStatsCollector(BaseCollector):
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'vcenter', 'datacenter', 'vccluster'])
+        if not gauges:
+            return
 
         uuids = self.get_hosts_by_target()
         for metric_suffix in gauges:

--- a/collectors/HostSystemStatsCollector.py
+++ b/collectors/HostSystemStatsCollector.py
@@ -23,9 +23,14 @@ class HostSystemStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'vcenter', 'datacenter', 'vccluster'])
-        if not gauges:
+        if not gauges and http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
             return
 
         uuids = self.get_hosts_by_target()

--- a/collectors/HostSystemStatsCollector.py
+++ b/collectors/HostSystemStatsCollector.py
@@ -23,15 +23,14 @@ class HostSystemStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
+
+        if not api_responding:
+            return
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'vcenter', 'datacenter', 'vccluster'])
-        if not gauges and http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
-            return
 
         uuids = self.get_hosts_by_target()
         for metric_suffix in gauges:

--- a/collectors/VCenterPropertiesCollector.py
+++ b/collectors/VCenterPropertiesCollector.py
@@ -23,12 +23,10 @@ class VCenterPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,

--- a/collectors/VCenterPropertiesCollector.py
+++ b/collectors/VCenterPropertiesCollector.py
@@ -23,6 +23,14 @@ class VCenterPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name])
         infos = self.generate_infos(self.name, self.vrops_entity_name,

--- a/collectors/VCenterStatsCollector.py
+++ b/collectors/VCenterStatsCollector.py
@@ -31,6 +31,8 @@ class VCenterStatsCollector(BaseCollector):
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name])
+        if not gauges:
+            return
 
         vc = self.get_vcenters(self.target)
         uuid = [vc[uuid]['uuid'] for uuid in vc][0]

--- a/collectors/VCenterStatsCollector.py
+++ b/collectors/VCenterStatsCollector.py
@@ -23,6 +23,14 @@ class VCenterStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name])
 

--- a/collectors/VCenterStatsCollector.py
+++ b/collectors/VCenterStatsCollector.py
@@ -23,12 +23,10 @@ class VCenterStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,

--- a/collectors/VMPropertiesCollector.py
+++ b/collectors/VMPropertiesCollector.py
@@ -23,12 +23,10 @@ class VMPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,

--- a/collectors/VMPropertiesCollector.py
+++ b/collectors/VMPropertiesCollector.py
@@ -23,6 +23,14 @@ class VMPropertiesCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         gauges = self.generate_gauges('property', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'vcenter', 'datacenter', 'vccluster', 'hostsystem',
                                        'project'])

--- a/collectors/VMStatsCollector.py
+++ b/collectors/VMStatsCollector.py
@@ -36,6 +36,9 @@ class VMStatsCollector(BaseCollector):
         gauges = self.generate_gauges('stats', self.name, self.vrops_entity_name,
                                       [self.vrops_entity_name, 'vcenter', 'datacenter', 'vccluster', 'hostsystem',
                                        'project'], rubric=self.rubric)
+        if not gauges:
+            return
+
         project_ids = self.get_project_ids_by_target()
 
         uuids = self.get_vms_by_target()

--- a/collectors/VMStatsCollector.py
+++ b/collectors/VMStatsCollector.py
@@ -24,12 +24,10 @@ class VMStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
-        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
-        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
-        yield http_gauge
+        api_responding, gauge = self.create_http_response_metric(self.target, token, self.name)
+        yield gauge
 
-        if http_response_code > 200:
-            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+        if not api_responding:
             return
 
         if self.rubricated and not self.rubric:

--- a/collectors/VMStatsCollector.py
+++ b/collectors/VMStatsCollector.py
@@ -24,6 +24,14 @@ class VMStatsCollector(BaseCollector):
             logger.warning(f'skipping {self.target} in {self.name}, no token')
             return
 
+        http_response_code, http_gauge = self.create_http_response_metric(self.target, token, self.name)
+        logger.debug(f'HTTP response code in {self.name} for {self.target}: {http_response_code}')
+        yield http_gauge
+
+        if http_response_code > 200:
+            logger.critical(f'HTTP response code in {self.name} for {self.target}: {http_response_code}, no return')
+            return
+
         if self.rubricated and not self.rubric:
             logger.warning(f'{self.name} has no rubric given. Considering all.')
 

--- a/exporter.py
+++ b/exporter.py
@@ -35,7 +35,7 @@ def parse_params(logger):
     parser.add_option("-m", "--config", help="path to config to set default collectors, statkeys and properties for "
                                              "collectors", action="store", dest="config")
     parser.add_option("-t", "--target", help="define target vrops", action="store", dest="target")
-    parser.add_option("-r", "--rubric", help="metric rubric only for VMStatsCollector", action="store", dest="rubric")
+    parser.add_option("-r", "--rubric", help="metric rubric in collector config", action="store", dest="rubric")
     (options, args) = parser.parse_args()
 
     if options.inventory:

--- a/inventory.py
+++ b/inventory.py
@@ -16,7 +16,7 @@ def parse_params(logger):
     parser = OptionParser()
     parser.add_option("-u", "--user", help="specify user to log in", action="store", dest="user")
     parser.add_option("-p", "--password", help="specify password to log in", action="store", dest="password")
-    parser.add_option("-o", "--port", help="specify exporter port", action="store", dest="port")
+    parser.add_option("-o", "--port", help="specify inventory port", action="store", dest="port")
     parser.add_option("-a", "--atlas", help="path to atlas configfile", action="store", dest="atlas")
     parser.add_option("-v", "--v", help="logging all level except debug", action="store_true", dest="info",
                       default=False)

--- a/tests/TestCollectors.py
+++ b/tests/TestCollectors.py
@@ -43,6 +43,7 @@ class TestCollectors(unittest.TestCase):
         Vrops.get_token = MagicMock(return_value="2ed214d523-235f-h283-4566-6sf356124fd62::f234234-234")
         Vrops.get_adapter = MagicMock(return_value=[{'name': "vcenter1", 'uuid': '5628-9ba1-55e84701'}])
         # test tool get_resources to create resource objects
+        Vrops.get_http_response_code = MagicMock(return_value=200)
 
         Vrops.get_datacenter = MagicMock(
             return_value=[{'name': 'datacenter1', 'uuid': '5628-9ba1-55e847050814'},

--- a/tests/metrics.yaml
+++ b/tests/metrics.yaml
@@ -1,6 +1,7 @@
 VCenterStatsCollector:
   rubrics: false
   metrics:
+    - 'vrops_api_response{class="vcenterstatscollector",target="testhost.test"}'
     - 'vrops_vcenter_cpu_used_percent{vcenter="vcenter1"}'
     - 'vrops_vcenter_memory_used_percent{vcenter="vcenter1"}'
     - 'vrops_vcenter_diskspace_total_gigabytes{vcenter="vcenter1"}'
@@ -10,12 +11,14 @@ VCenterStatsCollector:
 VCenterPropertiesCollector:
   rubrics: false
   metrics:
+    - 'vrops_api_response{class="vcenterpropertiescollector",target="testhost.test"}'
     - 'vrops_vcenter_summary_version_info{summary_version="test_property",vcenter="vcenter1"}'
     - 'vrops_vcenter_vc_fullname_info{vc_fullname="test_property",vcenter="vcenter1"}'
 
 ClusterStatsCollector:
   rubrics: false
   metrics:
+    - 'vrops_api_response{class="clusterstatscollector",target="testhost.test"}'
     - 'vrops_cluster_cpu_capacity_usage_percentage{datacenter="datacenter3",vccluster="cluster1",vcenter="vcenter1"}'
     - 'vrops_cluster_memory_usage_kilobytes{datacenter="datacenter3",vccluster="cluster1",vcenter="vcenter1"}'
     - 'vrops_cluster_memory_capacity_kilobytes{datacenter="datacenter3",vccluster="cluster3",vcenter="vcenter1"}'
@@ -44,6 +47,7 @@ ClusterStatsCollector:
 ClusterPropertiesCollector:
   rubrics: false
   metrics:
+    - 'vrops_api_response{class="clusterpropertiescollector",target="testhost.test"}'
     - 'vrops_cluster_configuration_dasconfig_admissioncontrolenabled{datacenter="datacenter3",state="test_enum_property",vccluster="cluster1",vcenter="vcenter1"}'
     - 'vrops_cluster_configuration_dasconfig_admissioncontrolenabled{datacenter="datacenter3",state="test_enum_property",vccluster="cluster2",vcenter="vcenter1"}'
     - 'vrops_cluster_configuration_dasconfig_admissioncontrolpolicyid{datacenter="datacenter3",vccluster="cluster1",vcenter="vcenter1"}'
@@ -66,6 +70,7 @@ ClusterPropertiesCollector:
 HostSystemStatsCollector:
   rubrics: false
   metrics:
+  - 'vrops_api_response{class="hostsystemstatscollector",target="testhost.test"}'
   - 'vrops_hostsystem_cpu_demand_percentage{datacenter="datacenter3",hostsystem="hostsystem2",vccluster="cluster3",vcenter="vcenter1"}'
   - 'vrops_hostsystem_cpu_usage_megahertz{datacenter="datacenter3",hostsystem="hostsystem3",vccluster="cluster3",vcenter="vcenter1"}'
   - 'vrops_hostsystem_cpu_sockets_number{datacenter="datacenter3",hostsystem="hostsystem2",vccluster="cluster3",vcenter="vcenter1"}'
@@ -160,6 +165,7 @@ HostSystemStatsCollector:
 HostSystemPropertiesCollector:
   rubrics: false
   metrics:
+     - 'vrops_api_response{class="hostsystempropertiescollector",target="testhost.test"}'
      - 'vrops_hostsystem_summary_version_info{datacenter="datacenter3",hostsystem="hostsystem1",summary_version="test_info_property",vccluster="cluster3",vcenter="vcenter1"}'
      - 'vrops_hostsystem_summary_version_info{datacenter="datacenter3",hostsystem="hostsystem3",summary_version="test_info_property",vccluster="cluster3",vcenter="vcenter1"}'
      - 'vrops_hostsystem_sys_build_info{datacenter="datacenter3",hostsystem="hostsystem1",sys_build="test_info_property",vccluster="cluster3",vcenter="vcenter1"}'
@@ -185,6 +191,7 @@ HostSystemPropertiesCollector:
 DatastoreStatsCollector:
   rubrics: false
   metrics:
+     - 'vrops_api_response{class="datastorestatscollector",target="testhost.test"}'
      - 'vrops_datastore_diskspace_freespace_gigabytes{datacenter="datacenter3",datastore="vmfs_vc-w-0_p_ssd_bb091_001",hostsystem="hostsystem3",type="vmfs_p_ssd",vccluster="cluster3",vcenter="vcenter1"}'
      - 'vrops_datastore_diskspace_freespace_gigabytes{datacenter="datacenter3",datastore="eph-bb112-1",hostsystem="hostsystem3",type="ephemeral",vccluster="cluster3",vcenter="vcenter1"}'
      - 'vrops_datastore_diskspace_capacity_gigabytes{datacenter="datacenter3",datastore="vmfs_vc-w-0_p_ssd_bb091_001",hostsystem="hostsystem3",type="vmfs_p_ssd",vccluster="cluster3",vcenter="vcenter1"}'
@@ -201,6 +208,7 @@ DatastoreStatsCollector:
 DatastorePropertiesCollector:
   rubrics: false
   metrics:
+     - 'vrops_api_response{class="datastorepropertiescollector",target="testhost.test"}'
      - 'vrops_datastore_summary_datastore_accessible{datacenter="datacenter3",datastore="vmfs_vc-w-0_p_ssd_bb091_001",hostsystem="hostsystem3",state="test_enum_property",type="vmfs_p_ssd",vccluster="cluster3",vcenter="vcenter1"}'
      - 'vrops_datastore_summary_datastore_accessible{datacenter="datacenter3",datastore="eph-bb112-1",hostsystem="hostsystem3",state="test_enum_property",type="ephemeral",vccluster="cluster3",vcenter="vcenter1"}'
      - 'vrops_datastore_summary_datastore_accessible{datacenter="datacenter3",datastore="B121_Management_DS03",hostsystem="hostsystem3",state="test_enum_property",type="Management",vccluster="cluster3",vcenter="vcenter1"}'
@@ -209,6 +217,7 @@ VMStatsCollector:
   rubrics: true
   metrics:
     network:
+      - 'vrops_api_response{class="vmstatscollector",target="testhost.test"}'
       - 'vrops_virtualmachine_network_packets_dropped_tx_number{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
       - 'vrops_virtualmachine_network_data_received_kilobytes_per_second{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
       - 'vrops_virtualmachine_network_data_received_kilobytes_per_second{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
@@ -231,6 +240,7 @@ VMStatsCollector:
       - 'vrops_virtualmachine_network_packets_tx_number{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm3"}'
       - 'vrops_virtualmachine_network_packets_dropped_rx_number{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
     cpu:
+      - 'vrops_api_response{class="vmstatscollector",target="testhost.test"}'
       - 'vrops_virtualmachine_number_vcpus_total{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
       - 'vrops_virtualmachine_number_vcpus_total{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
       - 'vrops_virtualmachine_cpu_demand_ratio{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm3"}'
@@ -256,6 +266,7 @@ VMStatsCollector:
       - 'vrops_virtualmachine_cpu_ready_ratio{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
       - 'vrops_virtualmachine_cpu_usage_ratio{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm3"}'
     memory:
+      - 'vrops_api_response{class="vmstatscollector",target="testhost.test"}'
       - 'vrops_virtualmachine_memory_ballooning_ratio{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
       - 'vrops_virtualmachine_memory_active_ratio{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
       - 'vrops_virtualmachine_swapped_memory_kilobytes{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
@@ -285,6 +296,7 @@ VMStatsCollector:
       - 'vrops_virtualmachine_memory_usage_average{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
 
     virtualdisk:
+      - 'vrops_api_response{class="vmstatscollector",target="testhost.test"}'
       - 'vrops_virtualmachine_virtual_disk_average_read_miliseconds{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
       - 'vrops_virtualmachine_virtual_disk_read_kilobytes_per_second{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
       - 'vrops_virtualmachine_virtual_disk_outstanding_io{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm3"}'
@@ -308,6 +320,7 @@ VMStatsCollector:
       - 'vrops_virtualmachine_virtual_disk_outstanding_write_number{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
 
     other:
+      - 'vrops_api_response{class="vmstatscollector",target="testhost.test"}'
       - 'vrops_virtualmachine_datastore_outstanding_io_requests{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
       - 'vrops_virtualmachine_datastore_total{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
       - 'vrops_virtualmachine_datastore_total{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm3"}'
@@ -336,6 +349,7 @@ VMStatsCollector:
 VMPropertiesCollector:
   rubrics: false
   metrics:
+    - 'vrops_api_response{class="vmpropertiescollector",target="testhost.test"}'
     - 'vrops_virtualmachine_summary_ethernetcards{datacenter="datacenter3",hostsystem="hostsystem3",project="internal",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm2"}'
     - 'vrops_virtualmachine_config_hardware_memory_kilobytes{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm1"}'
     - 'vrops_virtualmachine_config_hardware_memory_kilobytes{datacenter="datacenter3",hostsystem="hostsystem3",project="0815",vccluster="cluster3",vcenter="vcenter1",virtualmachine="vm3"}'

--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -58,7 +58,7 @@ class Vrops:
                                     headers=headers)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
-            return 408
+            return 503
 
         return response.status_code
 

--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -40,7 +40,7 @@ class Vrops:
             return False
 
     def get_http_response_code(target, token):
-        url = "https://" + target + "/suite-api/api/adapters"
+        url = "https://" + target + "/suite-api/api/resources"
         querystring = {
             "adapterKindKey": "VMWARE"
         }
@@ -58,7 +58,7 @@ class Vrops:
                                     headers=headers)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
-            return False
+            return 0
 
         return response.status_code
 
@@ -92,7 +92,7 @@ class Vrops:
                 adapters.append(res)
         else:
             logger.error(f'Problem getting adapter {target} : {response.text}')
-            return False
+            return adapters
 
         return adapters
 

--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -39,6 +39,29 @@ class Vrops:
             logger.error(f'Problem getting token from {target} : {response.text}')
             return False
 
+    def get_http_response_code(target, token):
+        url = "https://" + target + "/suite-api/api/adapters"
+        querystring = {
+            "adapterKindKey": "VMWARE"
+        }
+        headers = {
+            'Content-Type': "application/json",
+            'Accept': "application/json",
+            'Authorization': "vRealizeOpsToken " + token
+        }
+        disable_warnings(exceptions.InsecureRequestWarning)
+
+        try:
+            response = requests.get(url,
+                                    params=querystring,
+                                    verify=False,
+                                    headers=headers)
+        except Exception as e:
+            logger.error(f'Problem connecting to {target} - Error: {e}')
+            return False
+
+        return response.status_code
+
     def get_adapter(target, token):
         url = "https://" + target + "/suite-api/api/adapters"
         querystring = {

--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -58,7 +58,7 @@ class Vrops:
                                     headers=headers)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
-            return 0
+            return 408
 
         return response.status_code
 
@@ -81,7 +81,7 @@ class Vrops:
                                     headers=headers)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
-            return False
+            return adapters
 
         if response.status_code == 200:
             for resource in response.json()["adapterInstancesInfoDto"]:


### PR DESCRIPTION
Generating an api status code metric to check, if the vrops target is reachable to make further API calls. 

example out:
```
vrops_api_response{class="datastorepropertiescollector",collector="vrops-vc-a-0-default",target="vrops-vc-a-0.cc.qa-de-1.cloud.sap"} 200.0
vrops_api_response{class="vcenterstatscollector",collector="vrops-vc-a-0-default",target="vrops-vc-a-0.cc.qa-de-1.cloud.sap"} 200.0
vrops_api_response{class="hostsystemstatscollector",collector="vrops-vc-a-0-host,target="vrops-vc-a-0.cc.qa-de-1.cloud.sap"} 200.0
```