### PR TITLE
only fetch receiving objects

### DIFF
--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -102,7 +102,8 @@ class Vrops:
             'parentId': parentid,
             'adapterKind': 'VMware',
             'resourceKind': resourcekind,
-            'pageSize': '50000'
+            'pageSize': '50000',
+            'resourceStatus': 'DATA_RECEIVING',
         }
         headers = {
             'Content-Type': "application/json",


### PR DESCRIPTION
objects need to be active objects, otherwise it could happen that vROps is fetching dated objects and then the exporter reports on these old dated metrics and objects too.