### PR TITLE
added lxml parser

### DIFF
--- a/collectors/AlertCollector.py
+++ b/collectors/AlertCollector.py
@@ -10,6 +10,8 @@ class AlertCollector(BaseCollector):
     def __init__(self):
         super().__init__()
         self.alertdefinitions = self.get_alertdefinitions()
+        if not self.alertdefinitions:
+            logger.critical(f'{self.name} could not get the alertdefinitions from inventory. No mapping available.')
         self.resourcekind = list()
 
     def get_resource_uuids(self):
@@ -70,7 +72,7 @@ class AlertCollector(BaseCollector):
     def generate_alert_label_values(self, alerts):
         alert_labels = dict()
         for resource in alerts:
-            alert_entry = self.alertdefinitions.get(resource.get('alertDefinitionId'))
+            alert_entry = self.alertdefinitions.get(resource.get('alertDefinitionId', {}), {})
             for i, symptom in enumerate(alert_entry.get('symptoms', [])):
                 alert_labels[f'symptom_{i+1}_name'] = symptom.get('name', "n/a")
                 alert_labels[f'symptom_{i+1}_data'] = str(symptom.get('state', 'n/a'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Flask==1.1.1
 gevent
 cffi
 beautifulsoup4==4.9.3
+lxml


### PR DESCRIPTION
We have to install the `lxml` parser to use it. 
```python
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/vrops-exporter/InventoryBuilder.py", line 228, in query_vrops
    self.alertdefinitions = Vrops.get_alertdefinitions(vrops, target, token)
  File "/vrops-exporter/tools/Vrops.py", line 495, in get_alertdefinitions
    recommendation_entry['description'] = remove_html_tags(rd.get("description"))
  File "/vrops-exporter/tools/helper.py", line 20, in remove_html_tags
    soup = BeautifulSoup(text, features="lxml")
  File "/usr/lib/python3.9/site-packages/bs4/__init__.py", line 243, in __init__
    raise FeatureNotFound(
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?
```
This led to an empty `alertdefinitions` dict. 
```python
Traceback (most recent call last):
  File "/usr/lib/python3.9/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/usr/lib/python3.9/site-packages/prometheus_client/exposition.py", line 123, in prometheus_app
    status, header, output = _bake_output(registry, accept_header, params)
  File "/usr/lib/python3.9/site-packages/prometheus_client/exposition.py", line 105, in _bake_output
    output = encoder(registry)
  File "/usr/lib/python3.9/site-packages/prometheus_client/openmetrics/exposition.py", line 14, in generate_latest
    for metric in registry.collect():
  File "/usr/lib/python3.9/site-packages/prometheus_client/registry.py", line 83, in collect
    for metric in collector.collect():
  File "/vrops-exporter/collectors/AlertCollector.py", line 51, in collect
    alert_labels = self.generate_alert_label_values(alerts)
  File "/vrops-exporter/collectors/AlertCollector.py", line 74, in generate_alert_label_values
    for i, symptom in enumerate(alert_entry.get('symptoms', [])):
AttributeError: 'NoneType' object has no attribute 'get'

```