### PR TITLE
Add timeout to all requests

### DIFF
--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -31,6 +31,9 @@ class Vrops:
                                      verify=False,
                                      headers=headers,
                                      timeout=10)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'Request to {url} timed out. Error: {e}')
+            return False, 504
         except Exception as e:
             logger.error(f'Problem connecting to {target}. Error: {e}')
             return False, 503
@@ -58,7 +61,10 @@ class Vrops:
                                     params=querystring,
                                     verify=False,
                                     headers=headers,
-                                    timeout=60)
+                                    timeout=30)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'Request to {url} timed out. Error: {e}')
+            return adapter, 504
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
             return adapter, 503
@@ -122,7 +128,10 @@ class Vrops:
                                      params=querystring,
                                      verify=False,
                                      headers=headers,
-                                     timeout=60)
+                                     timeout=30)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'Request to {url} timed out. Error: {e}')
+            return resources, 504
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
             return resources, 503
@@ -312,6 +321,10 @@ class Vrops:
                                      verify=False,
                                      headers=headers,
                                      timeout=60)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'{collector} has timed out getting latest data from: {target} - Error: {e}')
+            q.put([[], 504, 999])
+            return
         except Exception as e:
             logger.error(f'{collector} has problems getting latest data from: {target} - Error: {e}')
             q.put([[], 503, 999])
@@ -362,7 +375,10 @@ class Vrops:
                                      params=querystring,
                                      verify=False,
                                      headers=headers,
-                                     timeout=60)
+                                     timeout=30)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'Request for getting project folder timed out - Error: {e}')
+            return [], 504
         except Exception as e:
             logger.error(f'Problem getting project folder - Error: {e}')
             return [], 503
@@ -431,7 +447,10 @@ class Vrops:
                                      params=querystring,
                                      verify=False,
                                      headers=headers,
-                                     timeout=60)
+                                     timeout=30)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'Request for getting project folder timed out - Error: {e}')
+            return [], 504
         except Exception as e:
             logger.error(f'Problem getting project folder - Error: {e}')
             return [], 503
@@ -476,7 +495,10 @@ class Vrops:
                                     params=querystring,
                                     verify=False,
                                     headers=headers,
-                                    timeout=60)
+                                    timeout=30)
+        except requests.exceptions.ReadTimeout as e:
+            logger.error(f'Request to {url} timed out. Error: {e}')
+            return {}
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
             return {}

--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -57,7 +57,8 @@ class Vrops:
             response = requests.get(url,
                                     params=querystring,
                                     verify=False,
-                                    headers=headers)
+                                    headers=headers,
+                                    timeout=60)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
             return adapter, 503
@@ -120,7 +121,8 @@ class Vrops:
                                      data=json.dumps(payload),
                                      params=querystring,
                                      verify=False,
-                                     headers=headers)
+                                     headers=headers,
+                                     timeout=60)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
             return resources, 503
@@ -359,7 +361,8 @@ class Vrops:
                                      data=json.dumps(payload),
                                      params=querystring,
                                      verify=False,
-                                     headers=headers)
+                                     headers=headers,
+                                     timeout=60)
         except Exception as e:
             logger.error(f'Problem getting project folder - Error: {e}')
             return [], 503
@@ -427,7 +430,8 @@ class Vrops:
                                      data=json.dumps(payload),
                                      params=querystring,
                                      verify=False,
-                                     headers=headers)
+                                     headers=headers,
+                                     timeout=60)
         except Exception as e:
             logger.error(f'Problem getting project folder - Error: {e}')
             return [], 503
@@ -471,7 +475,8 @@ class Vrops:
             response = requests.get(url,
                                     params=querystring,
                                     verify=False,
-                                    headers=headers)
+                                    headers=headers,
+                                    timeout=60)
         except Exception as e:
             logger.error(f'Problem connecting to {target} - Error: {e}')
             return {}


### PR DESCRIPTION
We recently observed exporters not returning the scrape request after 60 seconds, missing timeouts are most likely the reason for it. Adding standard timeout of 60 seconds, please adjust if necessary.