### PR TITLE
CustomInfoMetricsGenerator

### DIFF
--- a/collectors/CustomInfoMetricsGenerator.py
+++ b/collectors/CustomInfoMetricsGenerator.py
@@ -1,0 +1,26 @@
+from BaseCollector import BaseCollector
+
+from prometheus_client.core import InfoMetricFamily
+import logging
+
+logger = logging.getLogger('vrops-exporter')
+
+
+class CustomInfoMetricsGenerator(BaseCollector):
+
+    def __init__(self):
+        super().__init__()
+        self.name = self.__class__.__name__
+        self.custom_metrics = self.read_collector_config().get('CustomInfoMetricsGenerator')
+
+    def describe(self):
+        for entry in self.custom_metrics:
+            yield InfoMetricFamily(entry['metric'], 'vrops-exporter')
+
+    def collect(self):
+        logger.info(f'{self.name} starts with collecting the metrics')
+
+        for entry in self.custom_metrics:
+            custom_info_metric = InfoMetricFamily(entry['metric'], 'vrops-exporter', labels=['target'])
+            custom_info_metric.add_metric(labels=[self.target], value=entry['values_dict'])
+            yield custom_info_metric

--- a/tests/collector_config.yaml
+++ b/tests/collector_config.yaml
@@ -37,6 +37,12 @@ alerts:
     - 'IMMEDIATE'
   activeOnly: True
 
+CustomInfoMetricsGenerator:
+  - metric: 'vrops_virtualmachine_guest_tools_target_version'
+    values_dict:
+      # A dict with label: label_values
+      guest_tools_target_version: '10.2.0'
+
 ClusterPropertiesCollector:
   - metric_suffix: "configuration_dasConfig_admissionControlEnabled"
     expected: "true"


### PR DESCRIPTION
The present generator creates static vrops metrics from the collector configuration file. This is necessary because we had to set self-selected benchmarks, thresholds, etc. somewhere. In the initial case, we set a target version number that customers should minimally meet with their VMware vm tools. 

This will be a useful tool in the future to not force custom metrics into all vrops instances. 


The following example leads to this metric:
```ruby
vrops_virtualmachine_guest_tools_target_version_info{guest_tools_target_version="10.2.0", target="vrops-vc-a-0.cc.qa-de-1.cloud.sap"} 1.0
```