### PR TITLE
fixed func naming in vcops and sddc collectors

### DIFF
--- a/collectors/SDDCAlertCollector.py
+++ b/collectors/SDDCAlertCollector.py
@@ -11,7 +11,7 @@ class SDDCAlertCollector(AlertCollector):
         self.adapterkind = ["SDDCHealthAdapter"]
 
     def get_resource_uuids(self):
-        return self.get_sddc_health_objects_by_target()
+        return self.get_sddc_objects_by_target()
 
     def get_labels(self, resource_id, project_ids):
         return [self.sddc_objects[resource_id]['name'],

--- a/collectors/VcopsSelfMonitoringAlertCollector.py
+++ b/collectors/VcopsSelfMonitoringAlertCollector.py
@@ -11,7 +11,7 @@ class VcopsSelfMonitoringAlertCollector(AlertCollector):
         self.adapterkind = ["vCenter Operations Adapter"]
 
     def get_resource_uuids(self):
-        return self.get_vcops_self_monitoring_objects_by_target()
+        return self.get_vcops_objects_by_target()
 
     def get_labels(self, resource_id, project_ids):
         return [self.vcops_objects[resource_id]['name'],

--- a/collectors/VcopsSelfMonitoringPropertiesCollector.py
+++ b/collectors/VcopsSelfMonitoringPropertiesCollector.py
@@ -9,7 +9,7 @@ class VcopsSelfMonitoringPropertiesCollector(PropertiesCollector):
         self.label_names = [self.vrops_entity_name, 'target']
 
     def get_resource_uuids(self):
-        return self.get_vcops_self_monitoring_objects_by_target()
+        return self.get_vcops_objects_by_target()
 
     def get_labels(self, resource_id, project_ids):
         return [self.vcops_objects[resource_id]['name'],

--- a/collectors/VcopsSelfMonitoringStatsCollector.py
+++ b/collectors/VcopsSelfMonitoringStatsCollector.py
@@ -9,7 +9,7 @@ class VcopsSelfMonitoringStatsCollector(StatsCollector):
         self.label_names = [self.vrops_entity_name, 'target']
 
     def get_resource_uuids(self):
-        return self.get_vcops_self_monitoring_objects_by_target()
+        return self.get_vcops_objects_by_target()
 
     def get_labels(self, resource_id, project_ids):
         return [self.vcops_objects[resource_id]['name'],


### PR DESCRIPTION
Problems have occurred

```python 
AttributeError: 'VcopsSelfMonitoringPropertiesCollector' object has no attribute 'get_vcops_self_monitoring_objects_by_target'
Traceback (most recent call last):
  File "/usr/lib/python3.9/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/usr/lib/python3.9/site-packages/prometheus_client/exposition.py", line 118, in prometheus_app
    status, header, output = _bake_output(registry, accept_header, params)
  File "/usr/lib/python3.9/site-packages/prometheus_client/exposition.py", line 100, in _bake_output
    output = encoder(registry)
  File "/usr/lib/python3.9/site-packages/prometheus_client/openmetrics/exposition.py", line 21, in generate_latest
    for metric in registry.collect():
  File "/usr/lib/python3.9/site-packages/prometheus_client/registry.py", line 83, in collect
    yield from collector.collect()
  File "/vrops-exporter/collectors/PropertiesCollector.py", line 24, in collect
    uuids = self.get_resource_uuids()
  File "/vrops-exporter/collectors/VcopsSelfMonitoringPropertiesCollector.py", line 12, in get_resource_uuids
    return self.get_vcops_self_monitoring_objects_by_target()
```