### PR TITLE
Avoidance of multiple saving of alert definitions

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -157,10 +157,10 @@ class BaseCollector(ABC):
         self.sddc_objects = request.json() if request else {}
         return self.sddc_objects
 
-    def get_alertdefinitions(self):
-        request = requests.get(url="http://" + os.environ['INVENTORY'] + "/alertdefinitions")
-        self.alertdefinitions = request.json() if request else {}
-        return self.alertdefinitions
+    def get_alertdefinition(self, alert_id):
+        request = requests.get(url="http://" + os.environ['INVENTORY'] + "/alertdefinitions/{}".format(alert_id))
+        self.alertdefinition = request.json() if request else {}
+        return self.alertdefinition
 
     def get_iteration(self):
         self.iteration = self.do_request(url="http://" + os.environ['INVENTORY'] + "/iteration")

--- a/InventoryBuilder.py
+++ b/InventoryBuilder.py
@@ -283,7 +283,7 @@ class InventoryBuilder:
         self.vcops_dict[target] = vcops_adapter
         self.sddc_dict[target] = sddc_adapter
 
-        if iteration == 1:
+        if iteration == 1 and not self.alertdefinitions:
             self.alertdefinitions = Vrops.get_alertdefinitions(vrops, target, token)
         return True
 

--- a/InventoryBuilder.py
+++ b/InventoryBuilder.py
@@ -117,9 +117,9 @@ class InventoryBuilder:
         def sddc_health_objects(target, iteration):
             return self.iterated_inventory.get(str(iteration), {}).get('sddc_objects', {}).get(target, {})
 
-        @app.route('/alertdefinitions/', methods=['GET'])
-        def alert_alertdefinitions():
-            return self.alertdefinitions
+        @app.route('/alertdefinitions/<alert_id>', methods=['GET'])
+        def alert_alertdefinitions(alert_id):
+            return self.alertdefinitions[alert_id]
 
         @app.route('/iteration', methods=['GET'])
         def iteration():

--- a/collectors/AlertCollector.py
+++ b/collectors/AlertCollector.py
@@ -12,6 +12,7 @@ class AlertCollector(BaseCollector):
         super().__init__()
         self.resourcekind = list()
         self.adapterkind = list()
+        self.alert_entry_cache = dict()
 
     def get_resource_uuids(self):
         raise NotImplementedError("Please Implement this method")
@@ -70,9 +71,8 @@ class AlertCollector(BaseCollector):
     def generate_alert_label_values(self, alert):
         alert_id = alert.get('alertDefinitionId', {})
         alert_labels = dict()
-        alert_entry_cache = dict()
         alert_entry = self.get_alertdefinition(
-            alert_id) if alert_id not in alert_entry_cache else alert_entry_cache.get(alert_id)
+            alert_id) if alert_id not in self.alert_entry_cache else self.alert_entry_cache.get(alert_id)
         alert_labels['description'] = alert_entry.get('description', "n/a")
         for i, symptom in enumerate(alert_entry.get('symptoms', [])):
             alert_labels[f'symptom_{i+1}_name'] = symptom.get('name', "n/a")

--- a/collectors/AlertCollector.py
+++ b/collectors/AlertCollector.py
@@ -71,8 +71,7 @@ class AlertCollector(BaseCollector):
     def generate_alert_label_values(self, alert):
         alert_id = alert.get('alertDefinitionId', {})
         alert_labels = dict()
-        alert_entry = self.alert_entry_cache.get(alert_id, self.get_alertdefinition(alert_id))
-        self.alert_entry_cache[alert_id] = alert_entry
+        alert_entry = self.alert_entry_cache.setdefault(alert_id, self.get_alertdefinition(alert_id))
         alert_labels['description'] = alert_entry.get('description', "n/a")
         for i, symptom in enumerate(alert_entry.get('symptoms', [])):
             alert_labels[f'symptom_{i+1}_name'] = symptom.get('name', "n/a")

--- a/collectors/AlertCollector.py
+++ b/collectors/AlertCollector.py
@@ -71,11 +71,8 @@ class AlertCollector(BaseCollector):
     def generate_alert_label_values(self, alert):
         alert_id = alert.get('alertDefinitionId', {})
         alert_labels = dict()
-
-        alert_entry = self.get_alertdefinition(
-            alert_id) if alert_id not in self.alert_entry_cache else self.alert_entry_cache.get(alert_id)
+        alert_entry = self.alert_entry_cache.get(alert_id, self.get_alertdefinition(alert_id))
         self.alert_entry_cache[alert_id] = alert_entry
-
         alert_labels['description'] = alert_entry.get('description', "n/a")
         for i, symptom in enumerate(alert_entry.get('symptoms', [])):
             alert_labels[f'symptom_{i+1}_name'] = symptom.get('name', "n/a")

--- a/collectors/AlertCollector.py
+++ b/collectors/AlertCollector.py
@@ -10,13 +10,6 @@ class AlertCollector(BaseCollector):
 
     def __init__(self):
         super().__init__()
-        self.alertdefinitions = self.get_alertdefinitions()
-        while not self.alertdefinitions:
-            t = 60
-            logger.critical(f'{self.name} could not get the alertdefinitions from inventory.'
-                            f'Retrying in {t}s')
-            time.sleep(t)
-            self.alertdefinitions = self.get_alertdefinitions()
         self.resourcekind = list()
         self.adapterkind = list()
 
@@ -73,7 +66,7 @@ class AlertCollector(BaseCollector):
 
     def generate_alert_label_values(self, alert):
         alert_labels = dict()
-        alert_entry = self.alertdefinitions.get(alert.get('alertDefinitionId', {}), {})
+        alert_entry = self.get_alertdefinition(alert.get('alertDefinitionId', {}))
         alert_labels['description'] = alert_entry.get('description', "n/a")
         for i, symptom in enumerate(alert_entry.get('symptoms', [])):
             alert_labels[f'symptom_{i+1}_name'] = symptom.get('name', "n/a")

--- a/collectors/AlertCollector.py
+++ b/collectors/AlertCollector.py
@@ -71,8 +71,11 @@ class AlertCollector(BaseCollector):
     def generate_alert_label_values(self, alert):
         alert_id = alert.get('alertDefinitionId', {})
         alert_labels = dict()
+
         alert_entry = self.get_alertdefinition(
             alert_id) if alert_id not in self.alert_entry_cache else self.alert_entry_cache.get(alert_id)
+        self.alert_entry_cache[alert_id] = alert_entry
+
         alert_labels['description'] = alert_entry.get('description', "n/a")
         for i, symptom in enumerate(alert_entry.get('symptoms', [])):
             alert_labels[f'symptom_{i+1}_name'] = symptom.get('name', "n/a")


### PR DESCRIPTION
The alert definitions are a huge JSON blob that was retrieved and stored for each vrops instance and also for each alert collector. This consumed a lot of nonsensical memory.