### PR TITLE
Atlas http endpoint error handling and probe metric added

### DIFF
--- a/InventoryBuilder.py
+++ b/InventoryBuilder.py
@@ -179,9 +179,9 @@ class InventoryBuilder:
                     urllib3.exceptions.NewConnectionError) as err:
                 logger.error(f'Failed to establish a connection to: {self.atlas_path}, retrying in {self.sleep}s', err)
                 if not self.vrops_list:
-                    logger.critical(f'No targets found to start inventory collection, exit 0')
-                    sys.exit(0)
-                logger.info(f'continue with the old vrops_list')
+                    logger.critical(f'No targets found to start InventoryBuilder, exit 1')
+                    sys.exit(1)
+                logger.info(f'Continue with the old vrops_list')
                 return
 
             try:
@@ -189,9 +189,9 @@ class InventoryBuilder:
             except simplejson.errors.JSONDecodeError:
                 logger.error(f'Invalid json data in atlas netbox http response, Content-Type: "{response.headers.get("Content-Type")}"')
                 if not self.vrops_list:
-                    logger.critical(f'No targets found to start inventory collection, exit 0')
-                    sys.exit(0)
-                logger.info(f'continue with the old vrops_list')
+                    logger.critical(f'No targets found to start InventoryBuilder, exit 1')
+                    sys.exit(1)
+                logger.info(f'Continue with the old vrops_list')
                 return
 
             netbox_json = response.json()

--- a/InventoryBuilder.py
+++ b/InventoryBuilder.py
@@ -189,7 +189,7 @@ class InventoryBuilder:
             except simplejson.errors.JSONDecodeError:
                 logger.error(f'Invalid json data in atlas netbox http response, Content-Type: "{response.headers.get("Content-Type")}"')
                 if not self.vrops_list:
-                    logger.critical(f'No targets found to start InventoryBuilder, exit 1')
+                    logger.critical(f'No targets found to start InventoryBuilder, bailing out')
                     sys.exit(1)
                 logger.info(f'Continue with the old vrops_list')
                 return

--- a/InventoryBuilder.py
+++ b/InventoryBuilder.py
@@ -179,7 +179,7 @@ class InventoryBuilder:
                     urllib3.exceptions.NewConnectionError) as err:
                 logger.error(f'Failed to establish a connection to: {self.atlas_path}, retrying in {self.sleep}s', err)
                 if not self.vrops_list:
-                    logger.critical(f'No targets found to start InventoryBuilder, exit 1')
+                    logger.critical(f'No targets found to start InventoryBuilder, bailing out')
                     sys.exit(1)
                 logger.info(f'Continue with the old vrops_list')
                 return

--- a/collectors/InventoryCollector.py
+++ b/collectors/InventoryCollector.py
@@ -34,6 +34,8 @@ class InventoryCollector(BaseCollector):
             yield self.api_response_metric(target)
             yield self.collection_time_metric(target)
             yield self.inventory_targets_info(target)
+
+            # If Atlas is used for target discovery
             yield self.atlas_http_sd_endpoint_probe()
 
     def amount_inventory_resources(self, target):
@@ -66,9 +68,10 @@ class InventoryCollector(BaseCollector):
 
     def atlas_http_sd_endpoint_probe(self):
         atlas_response_gauge = GaugeMetricFamily('atlas_sd_response', 'vrops_inventory',
-                                               labels=['atlas_path'])
-        for atlas_patch, response_code in self.get_inventory_api_responses()['atlas'].items():
-            atlas_response_gauge.add_metric(labels=[atlas_patch], value=response_code)
+                                                 labels=['atlas_path'])
+        if atlas_endpoint_response := self.get_inventory_api_responses().get('atlas'):
+            for atlas_path, response_code in atlas_endpoint_response.items():
+                atlas_response_gauge.add_metric(labels=[atlas_path], value=response_code)
         return atlas_response_gauge
 
     def collection_time_metric(self, target):

--- a/collectors/InventoryCollector.py
+++ b/collectors/InventoryCollector.py
@@ -34,6 +34,7 @@ class InventoryCollector(BaseCollector):
             yield self.api_response_metric(target)
             yield self.collection_time_metric(target)
             yield self.inventory_targets_info(target)
+            yield self.atlas_http_sd_endpoint_probe()
 
     def amount_inventory_resources(self, target):
         gauges = list()
@@ -62,6 +63,13 @@ class InventoryCollector(BaseCollector):
             api_response_gauge.add_metric(labels=[target, self.name.lower(), get_request],
                                           value=status_code)
         return api_response_gauge
+
+    def atlas_http_sd_endpoint_probe(self):
+        atlas_response_gauge = GaugeMetricFamily('atlas_sd_response', 'vrops_inventory',
+                                               labels=['atlas_path'])
+        for atlas_patch, response_code in self.get_inventory_api_responses()['atlas'].items():
+            atlas_response_gauge.add_metric(labels=[atlas_patch], value=response_code)
+        return atlas_response_gauge
 
     def collection_time_metric(self, target):
         collection_time_gauge = GaugeMetricFamily('vrops_inventory_collection_time_seconds', 'vrops_inventory',

--- a/exporter.py
+++ b/exporter.py
@@ -68,16 +68,16 @@ def parse_params(logger):
 
     if "PORT" not in os.environ and not options.port:
         logger.error('Cannot start, please specify port with ENV or -o')
-        sys.exit(0)
+        sys.exit(1)
     if "INVENTORY" not in os.environ and not options.inventory:
         logger.error('Cannot start, please specify inventory with ENV or -i')
-        sys.exit(0)
+        sys.exit(1)
     if "COLLECTOR_CONFIG" not in os.environ and not options.config:
         logger.error('Cannot start, please specify collector config with ENV or -m')
-        sys.exit(0)
+        sys.exit(1)
     if not options.collectors:
         logger.error('Cannot start, no default collectors activated in config')
-        sys.exit(0)
+        sys.exit(1)
 
     return options
 

--- a/inventory.py
+++ b/inventory.py
@@ -70,21 +70,21 @@ def parse_params(logger):
 
     if "PORT" not in os.environ and not options.port:
         logger.error('Cannot start, please specify PORT with ENV or -o')
-        sys.exit(0)
+        sys.exit(1)
     if "USER" not in os.environ and not options.user:
         logger.error('Cannot start, please specify USER with ENV or -u')
-        sys.exit(0)
+        sys.exit(1)
     if "PASSWORD" not in os.environ and not options.password:
         logger.error('Cannot start, please specify PASSWORD with ENV or -p')
-        sys.exit(0)
+        sys.exit(1)
     if "INVENTORY_CONFIG" not in os.environ and not options.config:
         logger.error('Cannot start, please specify inventory config with ENV or -m')
-        sys.exit(0)
+        sys.exit(1)
     if "ATLAS" not in os.environ and not options.atlas:
         vrops_list = yaml_read(os.environ['INVENTORY_CONFIG']).get('vrops_targets')
         if not vrops_list:
             logger.error('Cannot start, please declare vrops_targets in inventory config or ATLAS path with ENV or -a')
-            sys.exit(0)
+            sys.exit(1)
 
     return options
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ beautifulsoup4==4.9.3
 lxml
 itsdangerous==1.1.0
 jinja2==3.0.3
+simplejson

--- a/tests/TestLaunchInventory.py
+++ b/tests/TestLaunchInventory.py
@@ -108,7 +108,7 @@ class TestLaunchExporter(TestCase):
         sys.argv = ['prog']
         with self.assertRaises(SystemExit) as se:
             parse_params(logger)
-        self.assertEqual(se.exception.code, 0, 'PORT, USER, ATLAS or PASSWORD are not set in ENV or command line!')
+        self.assertEqual(se.exception.code, 1, 'PORT, USER, ATLAS or PASSWORD are not set in ENV or command line!')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes the issue where the inventory builder hangs when requesting vrops targets from atlas http sd endpoint. Error handling is now targeted at various problems that may occur and runs regardless of a successful request. Only the first run is terminated with code 0 because the `vrops_list` is not initially populated. In addition, a probe metric is supplied by the `InventoryCollector` to monitor the atlas http sd endpoint.