### PR TITLE
Removed custom http code

### DIFF
--- a/tools/Vrops.py
+++ b/tools/Vrops.py
@@ -160,7 +160,7 @@ class Vrops:
                 if not relations:
                     resourcekinds_beautyfied = ', '.join(resourcekinds)
                     logger.warning(f'No child relation returned for {resourcekinds_beautyfied} from adapter {adapterkind} for {target}.')
-                    return resources, 901
+                    return resources, 204
                 for resource in relations:
                     resourcekind = resource["resource"]["resourceKey"]["resourceKindKey"]
                     resourcekind = re.sub("[^a-zA-Z]+", "", resourcekind)


### PR DESCRIPTION
The custom http code introduced crashes the dashboards and triggers a warning message as most are configured for codes over 500. The problem to be displayed is not really a problem as the resources may not be there and that is fine. We have set the code to 204, which means it is successful but does not contain any content.
