### PR TITLE
fix storagepod labeling

### DIFF
--- a/collectors/DatastorePropertiesCollector.py
+++ b/collectors/DatastorePropertiesCollector.py
@@ -13,12 +13,16 @@ class DatastorePropertiesCollector(PropertiesCollector):
         return self.get_datastores_by_target()
 
     def get_labels(self, resource_id, project_ids):
+        if 'storagepod' in self.label_names:
+            self.label_names.pop()
+
         label_values = [self.datastores[resource_id]['name'],
                         self.datastores[resource_id]['vcenter'],
                         self.datastores[resource_id]['type'],
                         self.datastores[resource_id]['parent_dc_name'].lower()] if resource_id in self.datastores else []
 
         if sc_name := self.datastores[resource_id].get('storage_cluster_name'):
+            self.label_names.append('storagepod')
             label_values.append(sc_name)
 
         return label_values

--- a/collectors/DatastoreStatsCollector.py
+++ b/collectors/DatastoreStatsCollector.py
@@ -12,12 +12,16 @@ class DatastoreStatsCollector(StatsCollector):
         return self.get_datastores_by_target()
 
     def get_labels(self, resource_id, project_ids):
+        if 'storagepod' in self.label_names:
+            self.label_names.pop()
+
         label_values = [self.datastores[resource_id]['name'],
                         self.datastores[resource_id]['vcenter'],
                         self.datastores[resource_id]['type'],
                         self.datastores[resource_id]['parent_dc_name'].lower()] if resource_id in self.datastores else []
 
         if sc_name := self.datastores[resource_id].get('storage_cluster_name'):
+            self.label_names.append('storagepod')
             label_values.append(sc_name)
 
         return label_values


### PR DESCRIPTION
The label `storagepod` incorrectly shows `PoweredOff` because it is given as a static label, even if it is not a datastore from a storagepod. 
```
vrops_datastore_summary_datastore_accessible{
        cluster="qa-de-1", 
        cluster_type="controlplane", 
        collector="vc-mgmt", 
        datacenter="qa-de-1d", 
        datastore="node00577", 
        job="vrops-exporter", 
        prometheus="vmware-monitoring/vmware", 
        region="qa-de-1", 
        storagepod="PoweredOff", 
        type="NVMe", 
        vcenter="vcenter"
}
```