### PR TITLE
catch sigterm in collect

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -4,6 +4,8 @@ import time
 import os
 import re
 import logging
+import signal
+import sys
 from tools.helper import yaml_read
 from tools.Vrops import Vrops
 from prometheus_client.core import GaugeMetricFamily, InfoMetricFamily
@@ -23,6 +25,9 @@ class BaseCollector(ABC):
         self.name = self.__class__.__name__
         self.label_names = []
         self.project_ids = []
+        self.am_i_killed = False
+        self.collect_running = False
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     @abstractmethod
     def collect(self):
@@ -371,3 +376,13 @@ class BaseCollector(ABC):
         for metric in collector_config[self.name]:
             metric_suffix = metric['metric_suffix']
             yield GaugeMetricFamily(f'vrops_{self.vrops_entity_name}_{metric_suffix.lower()}', 'vrops-exporter')
+
+    def exit_gracefully(self, signum, frame):
+        self.am_i_killed = True
+        if self.collect_running:
+            logger.warning('SIGTERM received, finishing current collect run.')
+            while self.collect_running:
+                time.sleep(1)
+        else:
+            logger.warning('SIGTERM received, bailing out.')
+        sys.exit(0)

--- a/collectors/PropertiesCollector.py
+++ b/collectors/PropertiesCollector.py
@@ -13,6 +13,9 @@ class PropertiesCollector(BaseCollector):
         raise NotImplementedError("Please Implement this method")
 
     def collect(self):
+        if self.collect_running and self.am_i_killed:
+            return
+        self.collect_running = True
         logger.info(f'{self.name} starts with collecting the metrics')
 
         token = self.get_target_tokens()
@@ -97,3 +100,4 @@ class PropertiesCollector(BaseCollector):
                                                           len(created_metrics[metric].samples))
             logger.info(f'Created metrics enriched by API in {self.name}: {created_metrics[metric].name}')
             yield created_metrics[metric]
+        self.collect_running = False

--- a/collectors/PropertiesCollector.py
+++ b/collectors/PropertiesCollector.py
@@ -13,7 +13,7 @@ class PropertiesCollector(BaseCollector):
         raise NotImplementedError("Please Implement this method")
 
     def collect(self):
-        if self.collect_running and self.am_i_killed:
+        if self.am_i_killed:
             return
         self.collect_running = True
         logger.info(f'{self.name} starts with collecting the metrics')

--- a/collectors/StatsCollector.py
+++ b/collectors/StatsCollector.py
@@ -14,6 +14,9 @@ class StatsCollector(BaseCollector):
         raise NotImplementedError("Please Implement this method")
 
     def collect(self):
+        if self.collect_running and self.am_i_killed:
+            return
+        self.collect_running = True
         logger.info(f'{self.name} starts with collecting the metrics')
 
         token = self.get_target_tokens()
@@ -77,3 +80,4 @@ class StatsCollector(BaseCollector):
                                                           len(created_metrics[metric].samples))
             logger.info(f'Created metrics enriched by API in {self.name}: {created_metrics[metric].name}')
             yield created_metrics[metric]
+        self.collect_running = False


### PR DESCRIPTION
The collector should finish its collect()-run when receiving a SIGTERM. This is mainly used for a use case in kubernetes, where the given pod can be killed which would interrupt the current collect-run. Should be combined with terminationGracePeriodSeconds to avoid k8s waiting forever. A sane value would be something along 120 which is plenty of time to finish gracefully.

Fixes #245 