### PR TITLE
sigterm for multiple collectors

### DIFF
--- a/collectors/PropertiesCollector.py
+++ b/collectors/PropertiesCollector.py
@@ -13,8 +13,6 @@ class PropertiesCollector(BaseCollector):
         raise NotImplementedError("Please Implement this method")
 
     def collect(self):
-        if self.am_i_killed:
-            return
         self.collect_running = True
         logger.info(f'{self.name} starts with collecting the metrics')
 

--- a/collectors/StatsCollector.py
+++ b/collectors/StatsCollector.py
@@ -14,8 +14,6 @@ class StatsCollector(BaseCollector):
         raise NotImplementedError("Please Implement this method")
 
     def collect(self):
-        if self.collect_running and self.am_i_killed:
-            return
         self.collect_running = True
         logger.info(f'{self.name} starts with collecting the metrics')
 


### PR DESCRIPTION
previous integration would only work if a single collector is registered. Multiple collectors would not be aware of the others being killed. Steering moved to exporter.py, as this is the only place where we are aware of the other instantiated collectors.