### PR TITLE
expose vrops node service states

### DIFF
--- a/BaseCollector.py
+++ b/BaseCollector.py
@@ -188,6 +188,11 @@ class BaseCollector(ABC):
         self.api_reponse_times = self.do_request(url="http://" + os.environ['INVENTORY'] + "/api_response_times")
         return self.api_responses, self.api_reponse_times
 
+    def get_service_states(self):
+        self.wait_for_inventory_data()
+        self.service_states = self.do_request(url="http://" + os.environ['INVENTORY'] + "/service_states")
+        return self.service_states
+
     def get_target_tokens(self):
         self.target_tokens = self.do_request(url="http://" + os.environ['INVENTORY'] + "/target_tokens")
         return self.target_tokens

--- a/collectors/InventoryCollector.py
+++ b/collectors/InventoryCollector.py
@@ -23,10 +23,12 @@ class InventoryCollector(BaseCollector):
     def collect(self):
         logger.info(f'{self.name} starts with collecting the metrics')
 
-        for gauge_metric in self.amount_inventory_resources(self.target):
-            yield gauge_metric
-        for response_metric in self.api_response_metric(self.target):
-            yield response_metric
+        for metric in self.amount_inventory_resources(self.target):
+            yield metric
+        for metric in self.api_response_metric(self.target):
+            yield metric
+        for metric in self.vrops_node_service_states(self.target):
+            yield metric
         yield self.iteration_metric(self.target)
         yield self.collection_time_metric(self.target)
         yield self.inventory_targets_info(self.target)
@@ -35,7 +37,8 @@ class InventoryCollector(BaseCollector):
         gauges = list()
         for resourcekind, amount in self.get_amount_resources().get(target, {"empty": 0}).items():
             if resourcekind == "empty":
-                logger.warning(f'InventoryBuilder could not capture resources for {target}')
+                logger.warning(
+                    f'InventoryBuilder could not capture resources for {target}')
             gauge = GaugeMetricFamily(f'vrops_inventory_{resourcekind}', f'Amount of {resourcekind} in inventory',
                                       labels=["target"])
             gauge.add_metric(labels=[target], value=amount)
@@ -43,7 +46,8 @@ class InventoryCollector(BaseCollector):
         return gauges
 
     def iteration_metric(self, target):
-        iteration_gauge = CounterMetricFamily('vrops_inventory_iteration', 'vrops_inventory', labels=["target"])
+        iteration_gauge = CounterMetricFamily(
+            'vrops_inventory_iteration', 'vrops_inventory', labels=["target"])
         iteration = self.get_iteration()
         if not iteration:
             return iteration_gauge
@@ -51,10 +55,16 @@ class InventoryCollector(BaseCollector):
         return iteration_gauge
 
     def api_response_metric(self, target):
-        api_response_gauge = GaugeMetricFamily('vrops_api_response', 'vrops_inventory',
-                                               labels=['target', 'class', 'get_request'])
-        api_response_time_gauge = GaugeMetricFamily('vrops_api_response_time_seconds', 'vrops_inventory',
-                                               labels=['target', 'class', 'get_request'])
+        api_response_gauge = GaugeMetricFamily('vrops_api_response',
+                                               'vrops_inventory',
+                                               labels=["target",
+                                                       "class",
+                                                       "get_request"])
+        api_response_time_gauge = GaugeMetricFamily('vrops_api_response_time_seconds',
+                                                    'vrops_inventory',
+                                                    labels=["target",
+                                                            "class",
+                                                            "get_request"])
 
         status_code_dict, time_dict = self.get_inventory_api_responses()
         if not status_code_dict[target]:
@@ -66,7 +76,7 @@ class InventoryCollector(BaseCollector):
                                           value=status_code)
         for get_request, response_time in time_dict[target].items():
             api_response_time_gauge.add_metric(labels=[target, self.name.lower(), get_request],
-                                          value=response_time)
+                                               value=response_time)
         return [api_response_gauge, api_response_time_gauge]
 
     def collection_time_metric(self, target):
@@ -75,7 +85,8 @@ class InventoryCollector(BaseCollector):
         collection_time = self.get_collection_times()[target]
         if not collection_time:
             return collection_time_gauge
-        collection_time_gauge.add_metric(labels=[target], value=collection_time)
+        collection_time_gauge.add_metric(
+            labels=[target], value=collection_time)
         return collection_time_gauge
 
     def inventory_targets_info(self, target):
@@ -83,3 +94,36 @@ class InventoryCollector(BaseCollector):
                                                   labels=["target"])
         inventory_target_info.add_metric(labels=[target], value=1)
         return inventory_target_info
+
+    def vrops_node_service_states(self, target):
+        vrops_node_service_health = GaugeMetricFamily('vrops_node_service_health',
+                                                      'vrops_inventory',
+                                                      labels=["target",
+                                                              "name",
+                                                              "health",
+                                                              "details"])
+        vrops_node_service_uptime = GaugeMetricFamily('vrops_node_service_uptime',
+                                                      'vrops_inventory',
+                                                      labels=["target",
+                                                              "name"])
+        vrops_node_service_start_time = GaugeMetricFamily('vrops_node_service_start_time',
+                                                          'vrops_inventory',
+                                                          labels=["target",
+                                                                  "name"])
+        service_states = self.get_service_states().get("service")
+        if not service_states:
+            return [vrops_node_service_health, vrops_node_service_uptime, vrops_node_service_start_time]
+
+        for service in service_states:
+            vrops_node_service_health.add_metric(labels=[target,
+                                                         service.get("name", "N/A").lower(),
+                                                         service.get("health", "N/A").lower(),
+                                                         service.get("details", "N/A").lower()],
+                                                 value=1)
+            vrops_node_service_uptime.add_metric(labels=[target,
+                                                         service.get("name", "N/A").lower()],
+                                                 value=service.get("uptime", 0))
+            vrops_node_service_start_time.add_metric(labels=[target,
+                                                             service.get("name", "N/A").lower()],
+                                                     value=service.get("startedOn", 0))
+        return [vrops_node_service_health, vrops_node_service_uptime, vrops_node_service_start_time]

--- a/collectors/InventoryCollector.py
+++ b/collectors/InventoryCollector.py
@@ -23,11 +23,9 @@ class InventoryCollector(BaseCollector):
     def collect(self):
         logger.info(f'{self.name} starts with collecting the metrics')
 
-        for metric in self.amount_inventory_resources(self.target):
-            yield metric
-        for metric in self.api_response_metric(self.target):
-            yield metric
-        for metric in self.vrops_node_service_states(self.target):
+        for metric in (self.amount_inventory_resources(self.target) +
+                       self.api_response_metric(self.target) +
+                       self.vrops_node_service_states(self.target)):
             yield metric
         yield self.iteration_metric(self.target)
         yield self.collection_time_metric(self.target)

--- a/inventory/Api.py
+++ b/inventory/Api.py
@@ -126,6 +126,11 @@ class InventoryApi:
             response_times = self.builder.response_times
             return json.dumps(response_times)
 
+        @app.route('/service_states', methods=['GET'])
+        def service_states():
+            service_states = self.builder.service_states
+            return json.dumps(service_states)
+
         # debugging purpose
         @app.route('/iteration_store', methods=['GET'])
         def iteration_store():

--- a/inventory/Builder.py
+++ b/inventory/Builder.py
@@ -25,6 +25,7 @@ class InventoryBuilder:
         self.vrops_collection_times = dict()
         self.response_codes = defaultdict(dict)
         self.response_times = defaultdict(dict)
+        self.service_states = dict()
         self.alertdefinitions = dict()
         self.successful_iteration_list = [0]
         self.am_i_killed = False
@@ -113,6 +114,9 @@ class InventoryBuilder:
 
         if iteration == 1 and not self.alertdefinitions:
             self.alertdefinitions = Vrops.get_alertdefinitions(vrops, target, token)
+
+        self.service_states, self.response_codes[target]["node_services"], self.response_times[target]["node_services"] = \
+            Vrops.get_service_states(vrops, target, token)
         return True
 
     def create_vcenter_objects(self, vrops, target: str, token: str, query_specs: dict):


### PR DESCRIPTION
vrops API exposes the internal state of services on `suite-api/api/deployment/node/services/info`
```json
{
  "service": [
    {
      "name": "ADMINUI",
      "health": "OK",
      "details": "Success, Service ADMINUI is running and responding",
      "uptime": 5717296262,
      "startedOn": 1673348078745
    },
    {
      "name": "CASA",
      "health": "OK",
      "details": "Success, Service CASA is running and responding",
      "uptime": 5717477120,
      "startedOn": 1673347897944
    },
    {
      "name": "COLLECTOR",
      "health": "OK",
      "details": "Success, Service COLLECTOR is running and responding",
      "uptime": 5717286442,
      "startedOn": 1673348088579
    },
    {
      "name": "API",
      "health": "OK",
      "details": "Success, Service API is running and responding",
      "uptime": 5717284954,
      "startedOn": 1673348090088
    },
    {
      "name": "LOCATOR",
      "health": "OK",
      "details": "Success, Service LOCATOR is running and responding"
    },
    {
      "name": "UI",
      "health": "OK",
      "details": "Success, Service UI is running and responding",
      "uptime": 5717296320,
      "startedOn": 1673348078745
    },
    {
      "name": "ANALYTICS",
      "health": "OK",
      "details": "Success, Service ANALYTICS is running and responding",
      "uptime": 5717288313,
      "startedOn": 1673348087601
    }
  ]
}
```
which we can use to self-monitor vrops nodes. This PR implements this functionality.
```yaml
# HELP vrops_node_service_health vrops_inventory
# TYPE vrops_node_service_health gauge
vrops_node_service_health{details="success, service casa is running and responding",health="ok",name="casa",target="vrops_fqdn"} 1.0
vrops_node_service_health{details="success, service collector is running and responding",health="ok",name="collector",target="vrops_fqdn"} 1.0
vrops_node_service_health{details="success, service ui is running and responding",health="ok",name="ui",target="vrops_fqdn"} 1.0
vrops_node_service_health{details="success, service analytics is running and responding",health="ok",name="analytics",target="vrops_fqdn"} 1.0
vrops_node_service_health{details="success, service api is running and responding",health="ok",name="api",target="vrops_fqdn"} 1.0
vrops_node_service_health{details="success, service locator is running and responding",health="ok",name="locator",target="vrops_fqdn"} 1.0
vrops_node_service_health{details="success, service adminui is running and responding",health="ok",name="adminui",target="vrops_fqdn"} 1.0
# HELP vrops_node_service_uptime vrops_inventory
# TYPE vrops_node_service_uptime gauge
vrops_node_service_uptime{name="casa",target="vrops_fqdn"} 5.453848444e+09
vrops_node_service_uptime{name="collector",target="vrops_fqdn"} 5.453659981e+09
vrops_node_service_uptime{name="ui",target="vrops_fqdn"} 5.453669525e+09
vrops_node_service_uptime{name="analytics",target="vrops_fqdn"} 5.45366204e+09
vrops_node_service_uptime{name="api",target="vrops_fqdn"} 5.453658501e+09
vrops_node_service_uptime{name="locator",target="vrops_fqdn"} 0.0
vrops_node_service_uptime{name="adminui",target="vrops_fqdn"} 5.453669625e+09
# HELP vrops_node_service_start_time vrops_inventory
# TYPE vrops_node_service_start_time gauge
vrops_node_service_start_time{name="casa",target="vrops_fqdn"} 1.673611099533e+012
vrops_node_service_start_time{name="collector",target="vrops_fqdn"} 1.67361128798e+012
vrops_node_service_start_time{name="ui",target="vrops_fqdn"} 1.673611278437e+012
vrops_node_service_start_time{name="analytics",target="vrops_fqdn"} 1.673611287079e+012
vrops_node_service_start_time{name="api",target="vrops_fqdn"} 1.673611289484e+012
vrops_node_service_start_time{name="locator",target="vrops_fqdn"} 0.0
vrops_node_service_start_time{name="adminui",target="vrops_fqdn"} 1.673611278437e+012
```